### PR TITLE
refactor: extract CLI commands to OOP classes

### DIFF
--- a/src/typysetup/commands/__init__.py
+++ b/src/typysetup/commands/__init__.py
@@ -1,5 +1,17 @@
 """Commands module for TyPySetup CLI."""
 
+from typysetup.commands.config_cmd import ConfigCommand
+from typysetup.commands.help_cmd import HelpCommand
+from typysetup.commands.history_cmd import HistoryCommand
+from typysetup.commands.list_cmd import ListCommand
+from typysetup.commands.preferences_cmd import PreferencesCommand
 from typysetup.commands.setup_orchestrator import SetupOrchestrator
 
-__all__ = ["SetupOrchestrator"]
+__all__ = [
+    "ConfigCommand",
+    "HelpCommand",
+    "HistoryCommand",
+    "ListCommand",
+    "PreferencesCommand",
+    "SetupOrchestrator",
+]

--- a/src/typysetup/commands/config_cmd.py
+++ b/src/typysetup/commands/config_cmd.py
@@ -1,0 +1,65 @@
+"""Config command - display project configuration."""
+
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from typysetup.core import ProjectConfigLoadError, ProjectConfigManager
+
+
+class ConfigCommand:
+    """Handles displaying project configuration.
+
+    Reads and displays the .typysetup/config.json file
+    for a given project directory.
+    """
+
+    def __init__(self):
+        """Initialize the config command handler."""
+        self.console = Console()
+
+    def execute(self, project: str) -> None:
+        """Execute the config command to display project configuration.
+
+        Args:
+            project: Path to the project directory.
+        """
+        project_path = Path(project).resolve()
+
+        if not project_path.exists():
+            self.console.print(f"[red]Error: Project directory not found: {project_path}[/red]")
+            raise typer.Exit(code=1)
+
+        config_manager = ProjectConfigManager(project_path)
+
+        if not config_manager.config_exists():
+            self._handle_no_config(project_path)
+
+        self._display_config(config_manager, project_path)
+
+    def _handle_no_config(self, project_path: Path) -> None:
+        """Handle case when no configuration exists.
+
+        Args:
+            project_path: Path to the project directory.
+        """
+        self.console.print(f"[yellow]No TyPySetup configuration found in {project_path}[/yellow]")
+        self.console.print("[dim]Run 'typysetup setup <path>' to create a new project setup.[/dim]")
+        raise typer.Exit(code=1)
+
+    def _display_config(self, config_manager: ProjectConfigManager, project_path: Path) -> None:
+        """Display the project configuration.
+
+        Args:
+            config_manager: ProjectConfigManager instance.
+            project_path: Path to the project directory.
+        """
+        try:
+            config_manager.display_config(project_path=project_path)
+        except ProjectConfigLoadError as e:
+            self.console.print(f"[red]Error loading configuration: {e}[/red]")
+            raise typer.Exit(code=1) from e
+        except Exception as e:
+            self.console.print(f"[red]Unexpected error: {e}[/red]")
+            raise typer.Exit(code=1) from e

--- a/src/typysetup/commands/help_cmd.py
+++ b/src/typysetup/commands/help_cmd.py
@@ -1,0 +1,187 @@
+"""Help command - show detailed help and usage examples."""
+
+from typing import Optional
+
+from rich.console import Console
+
+
+class HelpCommand:
+    """Handles displaying detailed help and usage examples.
+
+    Provides topic-based help for setup, workflows,
+    preferences, and general usage.
+    """
+
+    def __init__(self):
+        """Initialize the help command handler."""
+        self.console = Console()
+
+    def execute(self, topic: Optional[str]) -> None:
+        """Execute the help command.
+
+        Args:
+            topic: Specific help topic, or None for general help.
+        """
+        if not topic:
+            self._show_general_help()
+        elif topic.lower() == "setup":
+            self._show_setup_help()
+        elif topic.lower() == "workflows":
+            self._show_workflows_help()
+        elif topic.lower() == "preferences":
+            self._show_preferences_help()
+        else:
+            self._show_unknown_topic(topic)
+
+    def _show_general_help(self) -> None:
+        """Display general help information."""
+        self.console.print("[bold blue]TyPySetup - Python Environment Setup CLI[/bold blue]\n")
+        self.console.print(
+            "A powerful CLI tool for automating Python environment setup with VSCode integration.\n"
+        )
+
+        self._show_quick_start()
+        self._show_common_commands()
+        self._show_common_workflows()
+        self._show_help_topics()
+
+    def _show_quick_start(self) -> None:
+        """Display quick start instructions."""
+        self.console.print("[bold cyan]Quick Start:[/bold cyan]")
+        self.console.print(
+            "  1. [dim]typysetup list[/dim]                    # See available project types"
+        )
+        self.console.print(
+            "  2. [dim]typysetup setup /path/to/project[/dim]  # Start interactive setup"
+        )
+        self.console.print(
+            "  3. [dim]cd /path/to/project && source venv/bin/activate[/dim]  "
+            "# Activate environment\n"
+        )
+
+    def _show_common_commands(self) -> None:
+        """Display common commands list."""
+        self.console.print("[bold cyan]Common Commands:[/bold cyan]")
+        self.console.print(
+            "  [cyan]typysetup setup <path>[/cyan]       Run interactive setup wizard"
+        )
+        self.console.print("  [cyan]typysetup list[/cyan]               List available setup types")
+        self.console.print("  [cyan]typysetup preferences --show[/cyan] View your preferences")
+        self.console.print("  [cyan]typysetup config <path>[/cyan]      Show project configuration")
+        self.console.print(
+            "  [cyan]typysetup history[/cyan]            View recent setup history\n"
+        )
+
+    def _show_common_workflows(self) -> None:
+        """Display common workflow examples."""
+        self.console.print("[bold cyan]Common Workflows:[/bold cyan]")
+        self.console.print("  • [bold]New FastAPI Project:[/bold]")
+        self.console.print("    [dim]mkdir my-api && typysetup setup my-api[/dim]")
+        self.console.print("    [dim]# Select 'FastAPI' from the menu[/dim]\n")
+
+        self.console.print("  • [bold]Data Science Project:[/bold]")
+        self.console.print("    [dim]typysetup setup ml-project[/dim]")
+        self.console.print("    [dim]# Select 'Data Science' from the menu[/dim]\n")
+
+        self.console.print("  • [bold]Check Configuration:[/bold]")
+        self.console.print("    [dim]typysetup config /path/to/project[/dim]\n")
+
+    def _show_help_topics(self) -> None:
+        """Display available help topics."""
+        self.console.print("[bold cyan]Get Help on Specific Topics:[/bold cyan]")
+        self.console.print("  [dim]typysetup help setup[/dim]       # Detailed setup command help")
+        self.console.print("  [dim]typysetup help workflows[/dim]   # Common workflow examples")
+        self.console.print("  [dim]typysetup help preferences[/dim] # Managing preferences\n")
+        self.console.print("[dim]For command-specific help, use: typysetup <command> --help[/dim]")
+
+    def _show_setup_help(self) -> None:
+        """Display setup command help."""
+        self.console.print("[bold blue]Setup Command Help[/bold blue]\n")
+        self.console.print("[bold]Usage:[/bold] typysetup setup <path> [options]\n")
+
+        self.console.print("[bold cyan]What it does:[/bold cyan]")
+        self.console.print("  • Guides you through interactive project type selection")
+        self.console.print("  • Creates Python virtual environment")
+        self.console.print("  • Installs dependencies (uv/pip/poetry)")
+        self.console.print("  • Generates VSCode configuration")
+        self.console.print("  • Saves preferences for future use\n")
+
+        self.console.print("[bold cyan]Options:[/bold cyan]")
+        self.console.print("  [cyan]--verbose, -v[/cyan]  Enable detailed logging output\n")
+
+        self.console.print("[bold cyan]Examples:[/bold cyan]")
+        self.console.print("  [dim]# Basic setup[/dim]")
+        self.console.print("  typysetup setup my-project\n")
+        self.console.print("  [dim]# Setup with verbose output[/dim]")
+        self.console.print("  typysetup setup my-project --verbose\n")
+        self.console.print("  [dim]# Setup existing directory[/dim]")
+        self.console.print("  typysetup setup /home/user/existing-project\n")
+
+    def _show_workflows_help(self) -> None:
+        """Display workflows help."""
+        self.console.print("[bold blue]Common Workflows[/bold blue]\n")
+
+        self.console.print("[bold cyan]1. Starting a New FastAPI Project[/bold cyan]")
+        self.console.print("  mkdir my-api")
+        self.console.print("  cd my-api")
+        self.console.print("  typysetup setup .")
+        self.console.print("  [dim]# Select 'FastAPI' from the menu[/dim]")
+        self.console.print("  [dim]# Choose package manager (uv recommended)[/dim]")
+        self.console.print("  source venv/bin/activate")
+        self.console.print("  code .  [dim]# Open in VSCode[/dim]\n")
+
+        self.console.print("[bold cyan]2. Data Science Project with Jupyter[/bold cyan]")
+        self.console.print("  typysetup setup ml-analysis")
+        self.console.print("  [dim]# Select 'Data Science'[/dim]")
+        self.console.print("  cd ml-analysis")
+        self.console.print("  source venv/bin/activate")
+        self.console.print("  jupyter notebook  [dim]# Start Jupyter[/dim]\n")
+
+        self.console.print("[bold cyan]3. CLI Tool Development[/bold cyan]")
+        self.console.print("  typysetup setup my-cli-tool")
+        self.console.print("  [dim]# Select 'CLI Tool'[/dim]")
+        self.console.print("  cd my-cli-tool")
+        self.console.print("  source venv/bin/activate")
+        self.console.print("  [dim]# Start coding with Typer/Click[/dim]\n")
+
+        self.console.print("[bold cyan]4. Checking Existing Project[/bold cyan]")
+        self.console.print("  typysetup config /path/to/project")
+        self.console.print("  [dim]# View setup configuration[/dim]\n")
+
+        self.console.print("[bold cyan]5. Viewing Setup History[/bold cyan]")
+        self.console.print("  typysetup history")
+        self.console.print("  typysetup history --limit 20 --verbose")
+        self.console.print("  [dim]# See all your recent setups[/dim]\n")
+
+    def _show_preferences_help(self) -> None:
+        """Display preferences help."""
+        self.console.print("[bold blue]Managing Preferences[/bold blue]\n")
+
+        self.console.print("[bold cyan]View Current Preferences:[/bold cyan]")
+        self.console.print("  typysetup preferences --show\n")
+
+        self.console.print("[bold cyan]Reset to Defaults:[/bold cyan]")
+        self.console.print("  typysetup preferences --reset\n")
+
+        self.console.print("[bold cyan]What Gets Saved:[/bold cyan]")
+        self.console.print("  • Preferred package manager (uv/pip/poetry)")
+        self.console.print("  • Preferred Python version")
+        self.console.print("  • Favorite setup types")
+        self.console.print("  • Setup history (last 20 setups)")
+        self.console.print("  • VSCode config merge preferences\n")
+
+        self.console.print("[bold cyan]Preferences Location:[/bold cyan]")
+        self.console.print("  Linux/macOS: [dim]~/.typysetup/preferences.json[/dim]")
+        self.console.print("  Windows:     [dim]%APPDATA%\\typysetup\\preferences.json[/dim]\n")
+
+    def _show_unknown_topic(self, topic: str) -> None:
+        """Display message for unknown help topic.
+
+        Args:
+            topic: The unknown topic that was requested.
+        """
+        self.console.print(f"[yellow]Unknown help topic: {topic}[/yellow]")
+        self.console.print(
+            "\n[dim]Available topics: setup, list, preferences, config, history, workflows[/dim]"
+        )
+        self.console.print("[dim]Run 'typysetup help' for general help[/dim]")

--- a/src/typysetup/commands/history_cmd.py
+++ b/src/typysetup/commands/history_cmd.py
@@ -1,0 +1,161 @@
+"""History command - show recent setup history."""
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from typysetup.core import PreferenceManager
+
+
+class HistoryCommand:
+    """Handles displaying setup history.
+
+    Shows recent setup operations with status, duration,
+    and project details.
+    """
+
+    def __init__(self, preference_manager: PreferenceManager | None = None):
+        """Initialize with optional preference manager dependency.
+
+        Args:
+            preference_manager: PreferenceManager instance. If None, creates one.
+        """
+        self.preference_manager = preference_manager or PreferenceManager()
+        self.console = Console()
+
+    def execute(self, limit: int, verbose: bool) -> None:
+        """Execute the history command.
+
+        Args:
+            limit: Maximum number of entries to display.
+            verbose: If True, show additional columns.
+        """
+        try:
+            prefs = self.preference_manager.load_preferences()
+
+            if not prefs.setup_history:
+                self._handle_no_history()
+                return
+
+            self._display_history(prefs, limit, verbose)
+
+        except Exception as e:
+            self.console.print(f"[red]Error loading history: {e}[/red]")
+            raise typer.Exit(code=1) from e
+
+    def _handle_no_history(self) -> None:
+        """Handle case when no history exists."""
+        self.console.print("[yellow]No setup history found.[/yellow]")
+        self.console.print(
+            "[dim]Complete a setup with 'typysetup setup <path>' to see history.[/dim]"
+        )
+
+    def _display_history(self, prefs, limit: int, verbose: bool) -> None:
+        """Display the setup history table.
+
+        Args:
+            prefs: UserPreference object with setup history.
+            limit: Maximum number of entries to display.
+            verbose: If True, show additional columns.
+        """
+        self.console.print("\n[bold blue]Setup History[/bold blue]\n")
+
+        history_table = self._create_history_table(verbose)
+        recent_entries = self._get_recent_entries(prefs.setup_history, limit)
+
+        for entry in recent_entries:
+            row = self._format_history_row(entry, verbose)
+            history_table.add_row(*row)
+
+        self.console.print(history_table)
+        self._display_summary(prefs.setup_history, limit)
+
+    def _create_history_table(self, verbose: bool) -> Table:
+        """Create the history table with appropriate columns.
+
+        Args:
+            verbose: If True, include additional columns.
+
+        Returns:
+            Configured Table instance.
+        """
+        table = Table(show_header=True, header_style="bold cyan")
+        table.add_column("Date", style="cyan", width=20)
+        table.add_column("Status", style="white", width=10)
+        table.add_column("Setup Type", style="magenta", width=18)
+        table.add_column("Project", style="yellow", width=30)
+
+        if verbose:
+            table.add_column("Python", style="green", width=8)
+            table.add_column("Manager", style="blue", width=10)
+
+        table.add_column("Duration", style="dim", width=10)
+        return table
+
+    def _get_recent_entries(self, history: list, limit: int) -> list:
+        """Get the most recent history entries.
+
+        Args:
+            history: Full history list.
+            limit: Maximum entries to return.
+
+        Returns:
+            List of recent entries, newest first.
+        """
+        if limit and limit > 0:
+            sliced = history[-limit:]
+        else:
+            sliced = history
+        return list(reversed(sliced))
+
+    def _format_history_row(self, entry, verbose: bool) -> list:
+        """Format a history entry as a table row.
+
+        Args:
+            entry: SetupHistoryEntry object.
+            verbose: If True, include additional fields.
+
+        Returns:
+            List of formatted cell values.
+        """
+        date_str = entry.timestamp.strftime("%Y-%m-%d %H:%M")
+        status_icon = "[green]✓[/green]" if entry.success else "[red]✗[/red]"
+        duration_str = f"{entry.duration_seconds:.1f}s" if entry.duration_seconds else "—"
+
+        if entry.project_name:
+            project_display = entry.project_name
+        else:
+            project_display = entry.project_path.split("/")[-1]
+            if len(project_display) > 28:
+                project_display = project_display[:25] + "..."
+
+        row = [date_str, status_icon, entry.setup_type_slug, project_display]
+
+        if verbose:
+            row.append(entry.python_version or "—")
+            row.append(entry.package_manager or "—")
+
+        row.append(duration_str)
+        return row
+
+    def _display_summary(self, history: list, limit: int) -> None:
+        """Display history summary statistics.
+
+        Args:
+            history: Full history list.
+            limit: Display limit used.
+        """
+        total = len(history)
+        successful = sum(1 for e in history if e.success)
+        failed = total - successful
+
+        self.console.print(
+            f"\n[dim]Total: {total} setups | "
+            f"[green]✓ {successful} successful[/green] | "
+            f"[red]✗ {failed} failed[/red][/dim]\n"
+        )
+
+        if total > limit:
+            self.console.print(
+                f"[dim]Showing {limit} most recent. Use --limit to see more.[/dim]\n"
+            )

--- a/src/typysetup/commands/list_cmd.py
+++ b/src/typysetup/commands/list_cmd.py
@@ -1,0 +1,68 @@
+"""List command - show available setup type templates."""
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from typysetup.core import ConfigLoader
+
+
+class ListCommand:
+    """Handles listing available setup type templates.
+
+    Displays all configured setup types in a formatted table
+    with name, description, Python version, and supported managers.
+    """
+
+    def __init__(self, config_loader: ConfigLoader):
+        """Initialize with config loader dependency.
+
+        Args:
+            config_loader: ConfigLoader instance for loading setup types.
+        """
+        self.config_loader = config_loader
+        self.console = Console()
+
+    def execute(self) -> None:
+        """Execute the list command to display available setup types."""
+        self.console.print("[bold blue]Available Setup Types[/bold blue]\n")
+
+        try:
+            setup_types = self.config_loader.load_all_setup_types()
+
+            if not setup_types:
+                self.console.print("[yellow]No setup types found.[/yellow]")
+                return
+
+            self._display_setup_types_table(setup_types)
+
+        except Exception as e:
+            self.console.print(f"[red]Error loading setup types: {e}[/red]")
+            raise typer.Exit(code=1) from e
+
+    def _display_setup_types_table(self, setup_types: list) -> None:
+        """Display setup types in a formatted table.
+
+        Args:
+            setup_types: List of SetupType objects to display.
+        """
+        table = Table(title="TyPySetup Templates", show_header=True)
+        table.add_column("Name", style="cyan")
+        table.add_column("Description", style="magenta")
+        table.add_column("Python Version", style="green")
+        table.add_column("Package Managers", style="yellow")
+        table.add_column("Tags", style="blue")
+
+        for setup_type in setup_types:
+            managers = ", ".join(setup_type.supported_managers)
+            tags = ", ".join(setup_type.tags) if setup_type.tags else "—"
+            table.add_row(
+                setup_type.name,
+                setup_type.description,
+                setup_type.python_version,
+                managers,
+                tags,
+            )
+
+        self.console.print(table)
+        self.console.print(f"\n[dim]Total: {len(setup_types)} setup types available[/dim]")

--- a/src/typysetup/commands/preferences_cmd.py
+++ b/src/typysetup/commands/preferences_cmd.py
@@ -1,0 +1,159 @@
+"""Preferences command - manage user preferences."""
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from typysetup.core import PreferenceManager
+
+
+class PreferencesCommand:
+    """Handles user preferences management.
+
+    Provides functionality to view current preferences,
+    setup history, and reset preferences to defaults.
+    """
+
+    def __init__(self, preference_manager: PreferenceManager | None = None):
+        """Initialize with optional preference manager dependency.
+
+        Args:
+            preference_manager: PreferenceManager instance. If None, creates one.
+        """
+        self.preference_manager = preference_manager or PreferenceManager()
+        self.console = Console()
+
+    def execute(self, show: bool, reset: bool) -> None:
+        """Execute the preferences command.
+
+        Args:
+            show: If True, display current preferences.
+            reset: If True, reset preferences to defaults.
+        """
+        if show:
+            self._show_preferences()
+        elif reset:
+            self._reset_preferences()
+        else:
+            self._show_help()
+
+    def _show_preferences(self) -> None:
+        """Display current user preferences."""
+        try:
+            prefs = self.preference_manager.load_preferences()
+
+            self.console.print("[bold blue]User Preferences[/bold blue]\n")
+
+            self._display_main_preferences_table(prefs)
+            self._display_preferred_setup_types(prefs)
+            self._display_setup_history(prefs)
+
+            self.console.print(
+                f"\n[dim]Preferences file: {self.preference_manager.preferences_path}[/dim]"
+            )
+
+        except Exception as e:
+            self.console.print(f"[red]Error loading preferences: {e}[/red]")
+            raise typer.Exit(code=1) from e
+
+    def _display_main_preferences_table(self, prefs) -> None:
+        """Display main preferences in a table.
+
+        Args:
+            prefs: UserPreference object with preference data.
+        """
+        table = Table(title="Current Preferences", show_header=True, header_style="bold cyan")
+        table.add_column("Setting", style="cyan", width=30)
+        table.add_column("Value", style="green")
+
+        table.add_row("Preferred Package Manager", prefs.preferred_manager or "Not set")
+        table.add_row("Preferred Python Version", prefs.preferred_python_version or "Not set")
+        table.add_row("VSCode Config Merge Mode", prefs.vscode_config_merge_mode)
+        table.add_row("First Run", "Yes" if prefs.first_run else "No")
+        table.add_row("Schema Version", prefs.version)
+        table.add_row("Last Updated", prefs.last_updated.strftime("%Y-%m-%d %H:%M:%S UTC"))
+
+        self.console.print(table)
+        self.console.print()
+
+    def _display_preferred_setup_types(self, prefs) -> None:
+        """Display preferred setup types list.
+
+        Args:
+            prefs: UserPreference object with preference data.
+        """
+        if prefs.preferred_setup_types:
+            self.console.print("[bold cyan]Preferred Setup Types[/bold cyan]")
+            for i, setup_type in enumerate(prefs.preferred_setup_types, 1):
+                self.console.print(f"  {i}. {setup_type}")
+            self.console.print()
+
+    def _display_setup_history(self, prefs) -> None:
+        """Display setup history table.
+
+        Args:
+            prefs: UserPreference object with preference data.
+        """
+        if prefs.setup_history:
+            history_table = Table(
+                title="Recent Setup History", show_header=True, header_style="bold cyan"
+            )
+            history_table.add_column("Date", style="cyan", width=20)
+            history_table.add_column("Setup Type", style="magenta", width=20)
+            history_table.add_column("Project", style="yellow", width=25)
+            history_table.add_column("Status", style="green", width=10)
+            history_table.add_column("Duration", style="blue", width=10)
+
+            for entry in prefs.setup_history[-10:]:
+                date_str = entry.timestamp.strftime("%Y-%m-%d %H:%M")
+                status = "[green]Success[/green]" if entry.success else "[red]Failed[/red]"
+                duration = f"{entry.duration_seconds:.1f}s" if entry.duration_seconds else "N/A"
+                project_display = entry.project_name or entry.project_path.split("/")[-1]
+
+                history_table.add_row(
+                    date_str, entry.setup_type_slug, project_display, status, duration
+                )
+
+            self.console.print(history_table)
+            self.console.print(
+                f"\n[dim]Showing last {min(10, len(prefs.setup_history))} "
+                f"of {len(prefs.setup_history)} total entries[/dim]"
+            )
+        else:
+            self.console.print("[dim]No setup history yet.[/dim]\n")
+
+    def _reset_preferences(self) -> None:
+        """Reset preferences to defaults with confirmation."""
+        try:
+            import questionary
+
+            confirm = questionary.confirm(
+                "Are you sure you want to reset all preferences to defaults?",
+                default=False,
+            ).ask()
+
+            if not confirm:
+                self.console.print("[yellow]Reset cancelled.[/yellow]")
+                return
+
+            self.preference_manager.reset_to_defaults()
+            self.console.print("[green]Preferences reset to defaults successfully![/green]")
+            self.console.print(
+                f"[dim]Backup created at: "
+                f"{self.preference_manager.preferences_path.with_suffix('.json.backup_*')}[/dim]"
+            )
+
+        except Exception as e:
+            self.console.print(f"[red]Error resetting preferences: {e}[/red]")
+            raise typer.Exit(code=1) from e
+
+    def _show_help(self) -> None:
+        """Show preferences command help."""
+        self.console.print("[bold blue]TyPySetup Preferences[/bold blue]\n")
+        self.console.print("Manage your TyPySetup user preferences.\n")
+        self.console.print("Commands:")
+        self.console.print("  [cyan]--show[/cyan]   Display current preferences and setup history")
+        self.console.print("  [cyan]--reset[/cyan]  Reset all preferences to default values\n")
+        self.console.print("Example:")
+        self.console.print("  [dim]typysetup preferences --show[/dim]")
+        self.console.print("  [dim]typysetup preferences --reset[/dim]")

--- a/src/typysetup/main.py
+++ b/src/typysetup/main.py
@@ -5,9 +5,13 @@ from typing import Optional
 
 import typer
 from rich.console import Console
-from rich.table import Table
 
 from typysetup import __version__
+from typysetup.commands.config_cmd import ConfigCommand
+from typysetup.commands.help_cmd import HelpCommand
+from typysetup.commands.history_cmd import HistoryCommand
+from typysetup.commands.list_cmd import ListCommand
+from typysetup.commands.preferences_cmd import PreferencesCommand
 from typysetup.commands.setup_orchestrator import SetupOrchestrator
 from typysetup.core import ConfigLoader
 
@@ -26,7 +30,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Initialize config loader
+# Initialize shared dependencies
 config_loader = ConfigLoader()
 
 
@@ -54,43 +58,11 @@ def setup(
         raise typer.Exit(code=1)
 
 
-@app.command()
-def list() -> None:
+@app.command("list")
+def list_types() -> None:
     """List all available setup type templates."""
-    console.print("[bold blue]Available Setup Types[/bold blue]\n")
-
-    try:
-        setup_types = config_loader.load_all_setup_types()
-
-        if not setup_types:
-            console.print("[yellow]No setup types found.[/yellow]")
-            return
-
-        # Display in table format
-        table = Table(title="TyPySetup Templates", show_header=True)
-        table.add_column("Name", style="cyan")
-        table.add_column("Description", style="magenta")
-        table.add_column("Python Version", style="green")
-        table.add_column("Package Managers", style="yellow")
-        table.add_column("Tags", style="blue")
-
-        for setup_type in setup_types:
-            managers = ", ".join(setup_type.supported_managers)
-            tags = ", ".join(setup_type.tags) if setup_type.tags else "—"
-            table.add_row(
-                setup_type.name,
-                setup_type.description,
-                setup_type.python_version,
-                managers,
-                tags,
-            )
-
-        console.print(table)
-        console.print(f"\n[dim]Total: {len(setup_types)} setup types available[/dim]")
-
-    except Exception as e:
-        console.print(f"[red]Error loading setup types: {e}[/red]")
-        raise typer.Exit(code=1) from e
+    cmd = ListCommand(config_loader)
+    cmd.execute()
 
 
 @app.command()
@@ -99,107 +71,8 @@ def preferences(
     reset: bool = typer.Option(False, "--reset", help="Reset to defaults"),
 ) -> None:
     """Manage user preferences."""
-    from typysetup.core import PreferenceManager
-
-    pref_manager = PreferenceManager()
-
-    if show:
-        try:
-            prefs = pref_manager.load_preferences()
-
-            console.print("[bold blue]User Preferences[/bold blue]\n")
-
-            # Create main preferences table
-            table = Table(title="Current Preferences", show_header=True, header_style="bold cyan")
-            table.add_column("Setting", style="cyan", width=30)
-            table.add_column("Value", style="green")
-
-            table.add_row("Preferred Package Manager", prefs.preferred_manager or "Not set")
-            table.add_row("Preferred Python Version", prefs.preferred_python_version or "Not set")
-            table.add_row("VSCode Config Merge Mode", prefs.vscode_config_merge_mode)
-            table.add_row("First Run", "Yes" if prefs.first_run else "No")
-            table.add_row("Schema Version", prefs.version)
-            table.add_row("Last Updated", prefs.last_updated.strftime("%Y-%m-%d %H:%M:%S UTC"))
-
-            console.print(table)
-            console.print()
-
-            # Preferred setup types
-            if prefs.preferred_setup_types:
-                console.print("[bold cyan]Preferred Setup Types[/bold cyan]")
-                for i, setup_type in enumerate(prefs.preferred_setup_types, 1):
-                    console.print(f"  {i}. {setup_type}")
-                console.print()
-
-            # Setup history
-            if prefs.setup_history:
-                history_table = Table(
-                    title="Recent Setup History", show_header=True, header_style="bold cyan"
-                )
-                history_table.add_column("Date", style="cyan", width=20)
-                history_table.add_column("Setup Type", style="magenta", width=20)
-                history_table.add_column("Project", style="yellow", width=25)
-                history_table.add_column("Status", style="green", width=10)
-                history_table.add_column("Duration", style="blue", width=10)
-
-                # Show last 10 entries
-                for entry in prefs.setup_history[-10:]:
-                    date_str = entry.timestamp.strftime("%Y-%m-%d %H:%M")
-                    status = "[green]Success[/green]" if entry.success else "[red]Failed[/red]"
-                    duration = f"{entry.duration_seconds:.1f}s" if entry.duration_seconds else "N/A"
-                    project_display = entry.project_name or entry.project_path.split("/")[-1]
-
-                    history_table.add_row(
-                        date_str, entry.setup_type_slug, project_display, status, duration
-                    )
-
-                console.print(history_table)
-                console.print(
-                    f"\n[dim]Showing last {min(10, len(prefs.setup_history))} of {len(prefs.setup_history)} total entries[/dim]"
-                )
-            else:
-                console.print("[dim]No setup history yet.[/dim]\n")
-
-            # Show file location
-            console.print(f"\n[dim]Preferences file: {pref_manager.preferences_path}[/dim]")
-
-        except Exception as e:
-            console.print(f"[red]Error loading preferences: {e}[/red]")
-            raise typer.Exit(code=1) from e
-
-    elif reset:
-        try:
-            # Confirm reset
-            import questionary
-
-            confirm = questionary.confirm(
-                "Are you sure you want to reset all preferences to defaults?",
-                default=False,
-            ).ask()
-
-            if not confirm:
-                console.print("[yellow]Reset cancelled.[/yellow]")
-                return
-
-            pref_manager.reset_to_defaults()
-            console.print("[green]Preferences reset to defaults successfully![/green]")
-            console.print(
-                f"[dim]Backup created at: {pref_manager.preferences_path.with_suffix('.json.backup_*')}[/dim]"
-            )
-
-        except Exception as e:
-            console.print(f"[red]Error resetting preferences: {e}[/red]")
-            raise typer.Exit(code=1) from e
-
-    else:
-        console.print("[bold blue]TyPySetup Preferences[/bold blue]\n")
-        console.print("Manage your TyPySetup user preferences.\n")
-        console.print("Commands:")
-        console.print("  [cyan]--show[/cyan]   Display current preferences and setup history")
-        console.print("  [cyan]--reset[/cyan]  Reset all preferences to default values\n")
-        console.print("Example:")
-        console.print("  [dim]typysetup preferences --show[/dim]")
-        console.print("  [dim]typysetup preferences --reset[/dim]")
+    cmd = PreferencesCommand()
+    cmd.execute(show, reset)
 
 
 @app.command()
@@ -208,31 +81,8 @@ def config(
     show: bool = typer.Option(True, "--show", help="Show project configuration"),
 ) -> None:
     """Display project configuration from .typysetup/config.json."""
-    from pathlib import Path
-
-    from typysetup.core import ProjectConfigLoadError, ProjectConfigManager
-
-    project_path = Path(project).resolve()
-
-    if not project_path.exists():
-        console.print(f"[red]Error: Project directory not found: {project_path}[/red]")
-        raise typer.Exit(code=1)
-
-    config_manager = ProjectConfigManager(project_path)
-
-    if not config_manager.config_exists():
-        console.print(f"[yellow]No TyPySetup configuration found in {project_path}[/yellow]")
-        console.print("[dim]Run 'typysetup setup <path>' to create a new project setup.[/dim]")
-        raise typer.Exit(code=1)
-
-    try:
-        config_manager.display_config(project_path=project_path)
-    except ProjectConfigLoadError as e:
-        console.print(f"[red]Error loading configuration: {e}[/red]")
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        console.print(f"[red]Unexpected error: {e}[/red]")
-        raise typer.Exit(code=1) from e
+    cmd = ConfigCommand()
+    cmd.execute(project)
 
 
 @app.command()
@@ -241,94 +91,12 @@ def history(
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show detailed information"),
 ) -> None:
     """Show recent setup history."""
-    from typysetup.core import PreferenceManager
-
-    pref_manager = PreferenceManager()
-
-    try:
-        prefs = pref_manager.load_preferences()
-
-        if not prefs.setup_history:
-            console.print("[yellow]No setup history found.[/yellow]")
-            console.print(
-                "[dim]Complete a setup with 'typysetup setup <path>' to see history.[/dim]"
-            )
-            return
-
-        # Display history table
-        console.print("\n[bold blue]Setup History[/bold blue]\n")
-
-        history_table = Table(show_header=True, header_style="bold cyan")
-        history_table.add_column("Date", style="cyan", width=20)
-        history_table.add_column("Status", style="white", width=10)
-        history_table.add_column("Setup Type", style="magenta", width=18)
-        history_table.add_column("Project", style="yellow", width=30)
-
-        if verbose:
-            history_table.add_column("Python", style="green", width=8)
-            history_table.add_column("Manager", style="blue", width=10)
-
-        history_table.add_column("Duration", style="dim", width=10)
-
-        # Show last N entries (reversed to show newest first)
-        history_list = prefs.setup_history if prefs.setup_history else []
-        if limit and limit > 0:
-            sliced_history = history_list[-limit:]
-        else:
-            sliced_history = history_list
-        recent_entries = list(reversed(sliced_history))
-
-        for entry in recent_entries:
-            date_str = entry.timestamp.strftime("%Y-%m-%d %H:%M")
-            status_icon = "[green]✓[/green]" if entry.success else "[red]✗[/red]"
-            duration_str = f"{entry.duration_seconds:.1f}s" if entry.duration_seconds else "—"
-
-            # Get project name or extract from path
-            if entry.project_name:
-                project_display = entry.project_name
-            else:
-                project_display = entry.project_path.split("/")[-1]
-                # Truncate if too long
-                if len(project_display) > 28:
-                    project_display = project_display[:25] + "..."
-
-            row = [
-                date_str,
-                status_icon,
-                entry.setup_type_slug,
-                project_display,
-            ]
-
-            if verbose:
-                row.append(entry.python_version or "—")
-                row.append(entry.package_manager or "—")
-
-            row.append(duration_str)
-            history_table.add_row(*row)
-
-        console.print(history_table)
-
-        # Summary statistics
-        total = len(prefs.setup_history)
-        successful = sum(1 for e in prefs.setup_history if e.success)
-        failed = total - successful
-
-        console.print(
-            f"\n[dim]Total: {total} setups | "
-            f"[green]✓ {successful} successful[/green] | "
-            f"[red]✗ {failed} failed[/red][/dim]\n"
-        )
-
-        if total > limit:
-            console.print(f"[dim]Showing {limit} most recent. Use --limit to see more.[/dim]\n")
-
-    except Exception as e:
-        console.print(f"[red]Error loading history: {e}[/red]")
-        raise typer.Exit(code=1) from e
+    cmd = HistoryCommand()
+    cmd.execute(limit, verbose)
 
 
-@app.command()
-def help(
+@app.command("help")
+def help_topic(
     topic: Optional[str] = typer.Argument(None, help="Specific topic to get help for"),
 ) -> None:
     """
@@ -336,133 +104,8 @@ def help(
 
     Topics: setup, list, preferences, config, history, workflows
     """
-    if not topic:
-        # General help
-        console.print("[bold blue]TyPySetup - Python Environment Setup CLI[/bold blue]\n")
-        console.print(
-            "A powerful CLI tool for automating Python environment setup with VSCode integration.\n"
-        )
-
-        console.print("[bold cyan]Quick Start:[/bold cyan]")
-        console.print(
-            "  1. [dim]typysetup list[/dim]                    # See available project types"
-        )
-        console.print("  2. [dim]typysetup setup /path/to/project[/dim]  # Start interactive setup")
-        console.print(
-            "  3. [dim]cd /path/to/project && source venv/bin/activate[/dim]  # Activate environment\n"
-        )
-
-        console.print("[bold cyan]Common Commands:[/bold cyan]")
-        console.print("  [cyan]typysetup setup <path>[/cyan]       Run interactive setup wizard")
-        console.print("  [cyan]typysetup list[/cyan]               List available setup types")
-        console.print("  [cyan]typysetup preferences --show[/cyan] View your preferences")
-        console.print("  [cyan]typysetup config <path>[/cyan]      Show project configuration")
-        console.print("  [cyan]typysetup history[/cyan]            View recent setup history\n")
-
-        console.print("[bold cyan]Common Workflows:[/bold cyan]")
-        console.print("  • [bold]New FastAPI Project:[/bold]")
-        console.print("    [dim]mkdir my-api && typysetup setup my-api[/dim]")
-        console.print("    [dim]# Select 'FastAPI' from the menu[/dim]\n")
-
-        console.print("  • [bold]Data Science Project:[/bold]")
-        console.print("    [dim]typysetup setup ml-project[/dim]")
-        console.print("    [dim]# Select 'Data Science' from the menu[/dim]\n")
-
-        console.print("  • [bold]Check Configuration:[/bold]")
-        console.print("    [dim]typysetup config /path/to/project[/dim]\n")
-
-        console.print("[bold cyan]Get Help on Specific Topics:[/bold cyan]")
-        console.print("  [dim]typysetup help setup[/dim]       # Detailed setup command help")
-        console.print("  [dim]typysetup help workflows[/dim]   # Common workflow examples")
-        console.print("  [dim]typysetup help preferences[/dim] # Managing preferences\n")
-
-        console.print("[dim]For command-specific help, use: typysetup <command> --help[/dim]")
-
-    elif topic.lower() == "setup":
-        console.print("[bold blue]Setup Command Help[/bold blue]\n")
-        console.print("[bold]Usage:[/bold] typysetup setup <path> [options]\n")
-
-        console.print("[bold cyan]What it does:[/bold cyan]")
-        console.print("  • Guides you through interactive project type selection")
-        console.print("  • Creates Python virtual environment")
-        console.print("  • Installs dependencies (uv/pip/poetry)")
-        console.print("  • Generates VSCode configuration")
-        console.print("  • Saves preferences for future use\n")
-
-        console.print("[bold cyan]Options:[/bold cyan]")
-        console.print("  [cyan]--verbose, -v[/cyan]  Enable detailed logging output\n")
-
-        console.print("[bold cyan]Examples:[/bold cyan]")
-        console.print("  [dim]# Basic setup[/dim]")
-        console.print("  typysetup setup my-project\n")
-
-        console.print("  [dim]# Setup with verbose output[/dim]")
-        console.print("  typysetup setup my-project --verbose\n")
-
-        console.print("  [dim]# Setup existing directory[/dim]")
-        console.print("  typysetup setup /home/user/existing-project\n")
-
-    elif topic.lower() == "workflows":
-        console.print("[bold blue]Common Workflows[/bold blue]\n")
-
-        console.print("[bold cyan]1. Starting a New FastAPI Project[/bold cyan]")
-        console.print("  mkdir my-api")
-        console.print("  cd my-api")
-        console.print("  typysetup setup .")
-        console.print("  [dim]# Select 'FastAPI' from the menu[/dim]")
-        console.print("  [dim]# Choose package manager (uv recommended)[/dim]")
-        console.print("  source venv/bin/activate")
-        console.print("  code .  [dim]# Open in VSCode[/dim]\n")
-
-        console.print("[bold cyan]2. Data Science Project with Jupyter[/bold cyan]")
-        console.print("  typysetup setup ml-analysis")
-        console.print("  [dim]# Select 'Data Science'[/dim]")
-        console.print("  cd ml-analysis")
-        console.print("  source venv/bin/activate")
-        console.print("  jupyter notebook  [dim]# Start Jupyter[/dim]\n")
-
-        console.print("[bold cyan]3. CLI Tool Development[/bold cyan]")
-        console.print("  typysetup setup my-cli-tool")
-        console.print("  [dim]# Select 'CLI Tool'[/dim]")
-        console.print("  cd my-cli-tool")
-        console.print("  source venv/bin/activate")
-        console.print("  [dim]# Start coding with Typer/Click[/dim]\n")
-
-        console.print("[bold cyan]4. Checking Existing Project[/bold cyan]")
-        console.print("  typysetup config /path/to/project")
-        console.print("  [dim]# View setup configuration[/dim]\n")
-
-        console.print("[bold cyan]5. Viewing Setup History[/bold cyan]")
-        console.print("  typysetup history")
-        console.print("  typysetup history --limit 20 --verbose")
-        console.print("  [dim]# See all your recent setups[/dim]\n")
-
-    elif topic.lower() == "preferences":
-        console.print("[bold blue]Managing Preferences[/bold blue]\n")
-
-        console.print("[bold cyan]View Current Preferences:[/bold cyan]")
-        console.print("  typysetup preferences --show\n")
-
-        console.print("[bold cyan]Reset to Defaults:[/bold cyan]")
-        console.print("  typysetup preferences --reset\n")
-
-        console.print("[bold cyan]What Gets Saved:[/bold cyan]")
-        console.print("  • Preferred package manager (uv/pip/poetry)")
-        console.print("  • Preferred Python version")
-        console.print("  • Favorite setup types")
-        console.print("  • Setup history (last 20 setups)")
-        console.print("  • VSCode config merge preferences\n")
-
-        console.print("[bold cyan]Preferences Location:[/bold cyan]")
-        console.print("  Linux/macOS: [dim]~/.typysetup/preferences.json[/dim]")
-        console.print("  Windows:     [dim]%APPDATA%\\typysetup\\preferences.json[/dim]\n")
-
-    else:
-        console.print(f"[yellow]Unknown help topic: {topic}[/yellow]")
-        console.print(
-            "\n[dim]Available topics: setup, list, preferences, config, history, workflows[/dim]"
-        )
-        console.print("[dim]Run 'typysetup help' for general help[/dim]")
+    cmd = HelpCommand()
+    cmd.execute(topic)
 
 
 @app.callback(invoke_without_command=True)


### PR DESCRIPTION
## Summary

Refactor `main.py` to extract CLI command implementations into separate class-based modules, following the existing `SetupOrchestrator` pattern.

## Changes

### Architecture Improvement

| Before | After |
|--------|-------|
| `main.py`: 487 lines with all commands inline | `main.py`: 130 lines (thin entry point) |
| Functions scattered in single file | Class-based commands in dedicated modules |

### New Command Classes

| File | Class | Responsibility |
|------|-------|----------------|
| `list_cmd.py` | `ListCommand` | Display available setup type templates |
| `config_cmd.py` | `ConfigCommand` | Show project configuration |
| `preferences_cmd.py` | `PreferencesCommand` | Manage user preferences |
| `history_cmd.py` | `HistoryCommand` | Display setup history |
| `help_cmd.py` | `HelpCommand` | Show detailed help and examples |

### OOP Pattern Used

Each command follows the established pattern:

```python
class ListCommand:
    def __init__(self, config_loader: ConfigLoader):
        self.config_loader = config_loader
        self.console = Console()

    def execute(self) -> None:
        # Main command logic
        
    def _display_setup_types_table(self, setup_types: list) -> None:
        # Private helper methods
```

## Benefits

- **Maintainability**: Each command is self-contained and easier to modify
- **Testability**: Classes can be unit tested with dependency injection
- **Consistency**: Follows existing `SetupOrchestrator` pattern
- **Readability**: `main.py` now focuses on CLI registration only

## Testing

- [x] `pytest tests/integration/test_cli_commands.py` - 11/11 passed
- [x] `ruff check` - All checks passed
- [x] `black --check` - No formatting changes needed

## Stats

```
7 files changed, 673 insertions(+), 378 deletions(-)
main.py: 487 → 130 lines (-73%)
```